### PR TITLE
Add .htaccess file to publishDir and simplify syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,14 +131,14 @@ The program `makeHistPlots` can produce histograms from TnP trees. It can be use
 
 ### Publish directory as a web page
 
-The program `publishDir` copies a given file, e.g, the `index.php` file from this repository, recursively into a given directory. Then, it is easily browsable through a web browser, if the directory is accessed through a web server such as Apache. You can do this as CERN user, follow [this link](https://espace.cern.ch/webservices-help/websitemanagement/ManagingWebsitesAtCERN/Pages/WebsitecreationandmanagementatCERN.aspx) for more information. Following example shows an use-case in combination with the `makeRatioPlot` tool.
+The program `publishDir` copies a given file, e.g, the `index.php` file from this repository, recursively into a given directory. Then, it is easily browsable through a web browser, if the directory is accessed through a web server such as Apache. It is also adding an appropriate .htaccess file to ensure correct access to the webpages. You can do this as CERN user, follow [this link](https://espace.cern.ch/webservices-help/websitemanagement/ManagingWebsitesAtCERN/Pages/WebsitecreationandmanagementatCERN.aspx) for more information. Following example shows an use-case in combination with the `makeRatioPlot` tool.
 
 ```bash
 # Create plots
 ./makeRatioPlot examples/configRatioPlot.json
 
 # Make them accessable through a PHP web page
-./publishDir exampleRatio index.php
+./publishDir exampleRatio
 
 # Now, you need to copy the 'exampleRatio' folder to a directory,
 # which is accessible by the web server.

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ The program `makeHistPlots` can produce histograms from TnP trees. It can be use
 
 ### Publish directory as a web page
 
-The program `publishDir` copies a given file, e.g, the `index.php` file from this repository, recursively into a given directory. Then, it is easily browsable through a web browser, if the directory is accessed through a web server such as Apache. It is also adding an appropriate .htaccess file to ensure correct access to the webpages. You can do this as CERN user, follow [this link](https://espace.cern.ch/webservices-help/websitemanagement/ManagingWebsitesAtCERN/Pages/WebsitecreationandmanagementatCERN.aspx) for more information. Following example shows an use-case in combination with the `makeRatioPlot` tool.
+The program `publishDir` copies a given file, e.g, the `index.php` file from this repository, recursively into a given directory. Then, it is easily browsable through a web browser, if the directory is accessed through a web server such as Apache. It is also adding an appropriate `.htaccess` file to ensure correct access to the webpages. You can do this as CERN user, follow [this link](https://espace.cern.ch/webservices-help/websitemanagement/ManagingWebsitesAtCERN/Pages/WebsitecreationandmanagementatCERN.aspx) for more information. Following example shows an use-case in combination with the `makeRatioPlot` tool.
 
 ```bash
 # Create plots

--- a/htaccess
+++ b/htaccess
@@ -1,0 +1,12 @@
+Options +Indexes
+
+SSLRequireSSL # The modules only work using HTTPS
+AuthType shibboleth
+ShibRequireSession On
+ShibRequireAll On
+ShibExportAssertion Off
+
+Require valid-user
+Require ADFS_GROUP "cms-members"
+
+

--- a/publishDir
+++ b/publishDir
@@ -8,10 +8,15 @@ import os
 Setup argument parser
 """
 
+programDir = os.path.dirname(__file__)
+defaultPHP = os.path.join(programDir,"index.php")
+defaultHTA = os.path.join(programDir,"htaccess")
+
+
 parser = argparse.ArgumentParser(description="This program goes from the toplevel directory recursively downwards and places a index PHP in each directory. Then, it's possible to browse files more conveniently with a web browser. Note, that the PHP files have to be accessed through a web server such as Apache with PHP support.")
 parser.add_argument("toplevelDirectory", help="Path to the toplevel directory, which is the starting point for the recursion")
-parser.add_argument("-i", "--inputPHPfile", default="index.php", help="Path to the file source, which is placed in each directory")
-parser.add_argument("-a", "--accessFile", default="htaccess", help="Name of the file with the permissions to be put as .htacces in the base directory")
+parser.add_argument("-i", "--inputPHPfile", default=defaultPHP, help="Path to the file source, which is placed in each directory")
+parser.add_argument("-a", "--accessFile", default=defaultHTA, help="Name of the file with the permissions to be put as .htacces in the base directory")
 parser.add_argument("-o", "--outputFilename", default="index.php", help="Name of the output file, which is placed in each directory")
 parser.add_argument("-v", "--verbosity", default=1, help="Increase or decrease output verbosity")
 args = parser.parse_args()

--- a/publishDir
+++ b/publishDir
@@ -10,7 +10,8 @@ Setup argument parser
 
 parser = argparse.ArgumentParser(description="This program goes from the toplevel directory recursively downwards and places a index PHP in each directory. Then, it's possible to browse files more conveniently with a web browser. Note, that the PHP files have to be accessed through a web server such as Apache with PHP support.")
 parser.add_argument("toplevelDirectory", help="Path to the toplevel directory, which is the starting point for the recursion")
-parser.add_argument("inputPHPfile", help="Path to the file source, which is placed in each directory")
+parser.add_argument("-i", "--inputPHPfile", default="index.php", help="Path to the file source, which is placed in each directory")
+parser.add_argument("-a", "--accessFile", default="htaccess", help="Name of the file with the permissions to be put as .htacces in the base directory")
 parser.add_argument("-o", "--outputFilename", default="index.php", help="Name of the output file, which is placed in each directory")
 parser.add_argument("-v", "--verbosity", default=1, help="Increase or decrease output verbosity")
 args = parser.parse_args()
@@ -23,10 +24,17 @@ Go through directories from given toplevel directory and put the given PHP file 
 with open(args.inputPHPfile, 'r') as f:
     src = f.read()
 
+# Read input htaccess file
+with open(args.accessFile, 'r') as f:
+    access = f.read()
+
 # Walk downwards through toplevel directory and put given PHP file there
 if args.verbosity == 1:
     print('Start from toplevel dir: {}'.format(args.toplevelDirectory))
     print('Output filename: {}'.format(args.outputFilename))
+
+with open(os.path.join(args.toplevelDirectory, ".htaccess"), 'w') as f:
+    f.write(access)
 
 for currentDir, subdirs, files in os.walk(args.toplevelDirectory):
     if args.verbosity == 1:


### PR DESCRIPTION
This PR:

1. Adds to the publishDir script the possibility to append an .htaccess file to ensure that only people from CMS can access the published webpage

1. Simplifies a little the script syntax taking index.php as default file to be copied while pubilishing